### PR TITLE
Sitemap filename can't exceed 32 characters issue #13937 fixed.

### DIFF
--- a/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
+++ b/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
@@ -73,7 +73,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'name' => 'sitemap_filename',
                 'required' => true,
                 'note' => __('example: sitemap.xml'),
-                'value' => $model->getSitemapFilename()
+                'value' => $model->getSitemapFilename(),
+                'class' => 'validate-length maximum-length-32'
             ]
         );
 

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
@@ -12,6 +12,11 @@ use Magento\Framework\Controller;
 class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
 {
     /**
+     * Maximum length of sitemap filename
+     */
+    const MAX_FILENAME_LENGTH = 32;
+
+    /**
      * Validate path for generation
      *
      * @param array $data
@@ -35,6 +40,16 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                 // save data in session
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($data);
                 // redirect to edit form
+                return false;
+            }
+            $filename = rtrim($data['sitemap_filename']);
+            /** @var $lengthValidator \Magento\Framework\Validator\StringLength */
+            $lengthValidator = $this->_objectManager->create(\Magento\Framework\Validator\StringLength::class);
+            $lengthValidator->setMax(self::MAX_FILENAME_LENGTH);
+            if (!$lengthValidator->isValid($filename)) {
+                foreach ($lengthValidator->getMessages() as $message) {
+                    $this->messageManager->addErrorMessage($message);
+                }
                 return false;
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The Sitemap filename length validation was not added , hence added `\Magento\Framework\Validator\StringLength` max 32 length validation for sitemap filename and it will not trim filename exceeding 32 chars.     

### Fixed Issues (if relevant)

1. magento/magento2##13937: Issue title : Sitemap filename can't exceed 32 characters

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
